### PR TITLE
chore: Update CI Go version to 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
 go:
-  - 1.11.x
+  - 1.12.x
 
 script: make all


### PR DESCRIPTION
The TrustBloc fabric modules(fabric-mod/fabric-peer-ext) now support Go v1.12.x. Update the Go version in Travis CI config file.

Closes #15

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>