### PR TITLE
test: Add invoke/query CC step for target peers

### DIFF
--- a/bddtests/context.go
+++ b/bddtests/context.go
@@ -330,6 +330,22 @@ func (b *BDDContext) PeerConfigForURL(url string) *PeerConfig {
 	return nil
 }
 
+// PeerConfigForID returns the peer config for the given peer ID or nil if not found
+func (b *BDDContext) PeerConfigForID(id string) *PeerConfig {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	for _, pconfigs := range b.peersByChannel {
+		for _, pconfig := range pconfigs {
+			if pconfig.PeerID == id {
+				return pconfig
+			}
+		}
+	}
+	logger.Warnf("Peer config not found for ID [%s]", id)
+	return nil
+}
+
 // OrgIDForChannel returns a single org ID for the given channel or an error if
 // no orgs are configured for the channel
 func (b *BDDContext) OrgIDForChannel(channelID string) (string, error) {


### PR DESCRIPTION
Added common steps to invoke and query chaincode on a set of target peers.

closes #22

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>