### PR TITLE
test: Add get and set functions for query response

### DIFF
--- a/bddtests/common_steps.go
+++ b/bddtests/common_steps.go
@@ -1083,6 +1083,21 @@ func (d *CommonSteps) DefineCollectionConfig(id, name, policy string, requiredPe
 	)
 }
 
+// ClearResponse clears the query response
+func ClearResponse() {
+	queryValue = ""
+}
+
+// GetResponse returns the most recent query response
+func GetResponse() string {
+	return queryValue
+}
+
+// SetResponse sets the query response
+func SetResponse(response string) {
+	queryValue = response
+}
+
 // SetVar sets the value for the given variable
 func SetVar(varName, value string) {
 	vars[varName] = value


### PR DESCRIPTION
Added public functions to allow extended BDD steps to get and set the queryResponse variable.

closes #25

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>