### PR TITLE
feat: Added steps to decode base64 value

### DIFF
--- a/bddtests/utils.go
+++ b/bddtests/utils.go
@@ -250,6 +250,16 @@ func ResolveVars(val interface{}) (interface{}, error) {
 	}
 }
 
+// ResolveVars resolves all variables within the given expression
+func ResolveVarsInExpression(expr string) (string, error) {
+	resolved, err := ResolveVars(expr)
+	if err != nil {
+		return "", err
+	}
+
+	return resolved.(string), nil
+}
+
 func resolveMap(doc map[string]interface{}) (map[string]interface{}, error) {
 	m := make(map[string]interface{})
 	for field, val := range doc {


### PR DESCRIPTION
Added the following steps:
- Decode base64 value and save to variable
- Convert base64-encoded value to base64 URL-encoding and save to variable
- Compare two values

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>