### PR TITLE
fix: Fix memory leak in HTTP Client

### DIFF
--- a/bddtests/httpclient.go
+++ b/bddtests/httpclient.go
@@ -28,6 +28,7 @@ func (c *HTTPClient) Get(url string) ([]byte, int, http.Header, error) {
 	url = resolved.(string)
 
 	client := &http.Client{}
+	defer client.CloseIdleConnections()
 
 	if strings.HasPrefix(url, "https") {
 		// TODO add tls config https://github.com/trustbloc/fabric-peer-test-common/issues/51
@@ -66,6 +67,7 @@ func (c *HTTPClient) Get(url string) ([]byte, int, http.Header, error) {
 // Post posts the given data to the given URL
 func (c *HTTPClient) Post(url string, data []byte, contentType string) ([]byte, int, http.Header, error) {
 	client := &http.Client{}
+	defer client.CloseIdleConnections()
 
 	if strings.HasPrefix(url, "https") {
 		// TODO add tls config https://github.com/trustbloc/fabric-peer-test-common/issues/51


### PR DESCRIPTION
Call CloseIdleConnections after done with client.

closes #74

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>